### PR TITLE
Fix deployment to GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "/toolz-showcase-spectacle/",
+  build: {
+    outDir: "dist",
+  },
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
Update Vite configuration and package.json for proper deployment to GitHub Pages.

* **Vite Configuration (`vite.config.ts`)**
  - Add `base` option set to `"/toolz-showcase-spectacle/"` for proper routing in GitHub Pages.
  - Add `build` option with `outDir` set to `"dist"` for specifying the build output directory.

* **Package.json (`package.json`)**
  - Add a script for deploying to GitHub Pages using `gh-pages` under `scripts` section.

